### PR TITLE
Update etcdjs version and bump major version

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "chalk": "^0.4.0",
     "optimist": "^0.6.1",
     "lru-cache": "^2.5.0",
-    "etcdjs": "^1.1.1"
+    "etcdjs": "^2.0.2"
   },
   "devDependencies": {
     "tap": "~0.4.8"


### PR DESCRIPTION
`etcdjs` introduces a breaking change, where `options.refresh` defaults to `false`.